### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a fork of a great library by [Kim Biesbjerg](https://github.com/biesbjer
 
 ### Important notice
 The marker pipe and directive is not supported in Kim's ngx-translate-extract package.
-Please use [my fork](https://github.com/colsen1991/ngx-translate-extract) instead: `$ npm install @colsen1991/ngx-translate-extract`.
+Please use this official fork [ngx-translate-extract](https://github.com/vendure-ecommerce/ngx-translate-extract) instead: `$ npm install @vendure/ngx-translate-extract`.
 
 
 ## Mark strings for extraction using the marker function
@@ -80,7 +80,7 @@ export class YourModule {}
 ```
 
 ## ngx-translate-extract
-See [ngx-translate-extract](https://github.com/vendure-ecommerce/ngx-translate-extract) and [ngx-translate](https://github.com/ngx-translate/core) for more details.
+See [ngx-translate-extract](https://github.com/vendure-ecommerce/ngx-translate-extract) and [ngx-translate](https://ngx-translate.org) for more details.
 
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ export class YourModule {}
 ```
 
 ## ngx-translate-extract
-See [ngx-translate-extract](https://github.com/colsen1991/ngx-translate-extract) and [ngx-translate](https://github.com/ngx-translate/core) for more details.
+See [ngx-translate-extract](https://github.com/vendure-ecommerce/ngx-translate-extract) and [ngx-translate](https://github.com/ngx-translate/core) for more details.
+
 
 ## Credits
 Original library, idea and code: [@biesbjerg/ngx-translate-extract-marker](https://github.com/biesbjerg/ngx-translate-extract-marker) ❤️


### PR DESCRIPTION
Linking to [ngx-translate-extract](https://github.com/vendure-ecommerce/ngx-translate-extract) instead of the deprecated repo.